### PR TITLE
Fix link from fhir-path-custom-functions.md to CustomFHIRFunctions.kt

### DIFF
--- a/docs/fhir-path-custom-functions.md
+++ b/docs/fhir-path-custom-functions.md
@@ -3,7 +3,7 @@ This FHIR converter library includes custom FHIR Path functions that can be used
 Engine.
 
 For the most up-to-date list of custom functions please refer to the code in the
-[CustomFHIRFunctions.kt](../blob/master/src/main/kotlin/gov/cdc/prime/fhirconverter/translation/hl7/utils/CustomFHIRFunctions.kt)
+[CustomFHIRFunctions.kt](../src/main/kotlin/gov/cdc/prime/fhirconverter/translation/hl7/utils/CustomFHIRFunctions.kt)
 file.
 
 # Usage


### PR DESCRIPTION
The existing link duplicates "/blob/master."  The proposed change eliminates the duplicate part of the URL.